### PR TITLE
Fixed compile on linux and recent GCC

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -1,7 +1,8 @@
 # -D_XOPEN_SOURCE : required for getopt(3)
 # -D_DEFAULT_SOURCE : required for random(3)
 # -lm : required by ceil(3)
-CFLAGS = -Wall -O2 -std=c99 -lm -lncurses -D_XOPEN_SOURCE -D_DEFAULT_SOURCE
+CFLAGS = -Wall -O2 -std=c99 -D_XOPEN_SOURCE -D_DEFAULT_SOURCE
+LDLIBS = -lm -lncurses
 
 clean :
 	-rm cursbench


### PR DESCRIPTION
The order of parameters to GCC is significant. Libraries go to the `LDLIBS` variable so `make` can place them after the source file, not before, when invoking `gcc`.